### PR TITLE
Move from Ubuntu 16.04

### DIFF
--- a/.github/workflows/range-v3-ci.yml
+++ b/.github/workflows/range-v3-ci.yml
@@ -18,7 +18,7 @@ jobs:
         # GCC-6
         - {
             name: "Linux GCC 6 Debug (C++14)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "gcc-6", cxx: "g++-6",
             cxx_standard: 14,
@@ -26,7 +26,7 @@ jobs:
           }
         - {
             name: "Linux GCC 6 Release (C++14)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-6", cxx: "g++-6",
             cxx_standard: 14,
@@ -34,7 +34,7 @@ jobs:
           }
         - {
             name: "Linux GCC 6 Debug (C++17)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "gcc-6", cxx: "g++-6",
             cxx_standard: 17,
@@ -42,7 +42,7 @@ jobs:
           }
         - {
             name: "Linux GCC 6 Release (C++17)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-6", cxx: "g++-6",
             cxx_standard: 17,
@@ -50,7 +50,7 @@ jobs:
           }
         - {
             name: "Linux GCC 6 Release (C++17, Concepts)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-6", cxx: "g++-6",
             cxx_standard: 17,
@@ -59,7 +59,7 @@ jobs:
         # GCC-7
         - {
             name: "Linux GCC 7 Debug (C++14)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "gcc-7", cxx: "g++-7",
             cxx_standard: 14,
@@ -67,7 +67,7 @@ jobs:
           }
         - {
             name: "Linux GCC 7 Release (C++14)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-7", cxx: "g++-7",
             cxx_standard: 14,
@@ -75,7 +75,7 @@ jobs:
           }
         - {
             name: "Linux GCC 7 Debug (C++17)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "gcc-7", cxx: "g++-7",
             cxx_standard: 17,
@@ -83,7 +83,7 @@ jobs:
           }
         - {
             name: "Linux GCC 7 Release (C++17)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-7", cxx: "g++-7",
             cxx_standard: 17,
@@ -91,7 +91,7 @@ jobs:
           }
         - {
             name: "Linux GCC 7 Release (C++17, Concepts)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-7", cxx: "g++-7",
             cxx_standard: 17,
@@ -100,7 +100,7 @@ jobs:
         # GCC-8
         - {
             name: "Linux GCC 8 Debug (C++14)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "gcc-8", cxx: "g++-8",
             cxx_standard: 14,
@@ -108,7 +108,7 @@ jobs:
           }
         - {
             name: "Linux GCC 8 Release (C++14)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-8", cxx: "g++-8",
             cxx_standard: 14,
@@ -116,7 +116,7 @@ jobs:
           }
         - {
             name: "Linux GCC 8 Debug (C++17)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "gcc-8", cxx: "g++-8",
             cxx_standard: 17,
@@ -124,7 +124,7 @@ jobs:
           }
         - {
             name: "Linux GCC 8 Release (C++17)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-8", cxx: "g++-8",
             cxx_standard: 17,
@@ -132,7 +132,7 @@ jobs:
           }
         - {
             name: "Linux GCC 8 Release (C++17, Concepts)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: RelWithDebInfo,
             cc: "gcc-8", cxx: "g++-8",
             cxx_standard: 17,
@@ -198,7 +198,7 @@ jobs:
         # Clang-5.0
         - {
             name: "Linux Clang 5.0 Debug (C++14 / libc++ / ASAN)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "clang-5.0", cxx: "clang++-5.0",
             cxx_standard: 14,
@@ -207,7 +207,7 @@ jobs:
           }
         - {
             name: "Linux Clang 5.0 Debug (C++17 / ASAN)", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: Debug,
             cc: "clang-5.0", cxx: "clang++-5.0",
             cxx_standard: 17,


### PR DESCRIPTION
Ubuntu 16.04 LTS virtual environment was removed from GitHub Actions on September 20, 2021

https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/